### PR TITLE
feat: Implement game variables for launch parameters

### DIFF
--- a/LaunchMate.cs
+++ b/LaunchMate.cs
@@ -260,7 +260,7 @@ namespace LaunchMate
             {
                 logger.Info($"Conditions passed, waiting {group.LaunchDelay} ms to execute action for group \"{group.Name}\"");
                 System.Threading.Thread.Sleep(group.LaunchDelay);
-                if (group.Action.Execute(group.Name) && group.AutoClose){
+                if (group.Action.Execute(group.Name, args: args) && group.AutoClose){
                     toClose.Push(group);
                 }
             }

--- a/Models/Actions/ActionBase.cs
+++ b/Models/Actions/ActionBase.cs
@@ -22,7 +22,7 @@ namespace LaunchMate.Models
         /// </summary>
         /// <param name="groupName">The name of the group executing the action</param>
         /// <returns>true if the execution was successful, false otherwise</returns>
-        public abstract bool Execute(string groupName, Screen screen = null);
+        public abstract bool Execute(string groupName, Screen screen = null, Playnite.SDK.Events.OnGameStartingEventArgs args = null);
 
         /// <summary>
         /// Automatically closes something launched by <see cref="Execute(string)", if applicable/>

--- a/Models/Actions/AppAction.cs
+++ b/Models/Actions/AppAction.cs
@@ -19,7 +19,7 @@ namespace LaunchMate.Models
 
         //public string LnkName { get => _lnkName; set => SetValue(ref _lnkName, value); }
 
-        public override bool Execute(string groupName, Screen screen = null)
+        public override bool Execute(string groupName, Screen screen = null, Playnite.SDK.Events.OnGameStartingEventArgs args = null)
         {
             ILogger logger = LogManager.GetLogger();
             if (screen == null)
@@ -31,13 +31,21 @@ namespace LaunchMate.Models
             {
                 return false;
             }
-            logger.Info($"{groupName} - Launching application \"{Target}\" with arguments \"{TargetArgs}\"");
+
+            string processedArgs = TargetArgs;
+            if (args != null)
+            {
+                processedArgs = processedArgs.Replace("%GameDir%", args.Game.InstallDirectory);
+                processedArgs = processedArgs.Replace("%GameExe%", args.Game.GameActions.First().Path);
+            }
+
+            logger.Info($"{groupName} - Launching application \"{Target}\" with arguments \"{processedArgs}\"");
             try
             {
                 API.Instance.Notifications.Remove($"{groupName} - Error: {Target}");
                 ProcessStartInfo startInfo = new ProcessStartInfo(Target)
                 {
-                    Arguments = TargetArgs
+                    Arguments = processedArgs
                 };
                 Process p = Process.Start(startInfo);
                 //MoveWindow(p, screen);

--- a/Models/Actions/CloseAction.cs
+++ b/Models/Actions/CloseAction.cs
@@ -12,7 +12,7 @@ namespace LaunchMate.Models
 {
     public class CloseAction : ActionBase
     {
-        public override bool Execute(string groupName, Screen screen = null)
+        public override bool Execute(string groupName, Screen screen = null, Playnite.SDK.Events.OnGameStartingEventArgs args = null)
         {
             ILogger logger = LogManager.GetLogger();
             if ((Target ?? "") == string.Empty)

--- a/Models/Actions/IAction.cs
+++ b/Models/Actions/IAction.cs
@@ -14,7 +14,7 @@ namespace LaunchMate.Models
         string Target { get; set; }
         string TargetArgs { get; set; }
         Screen OpenScreen { get; set; }
-        bool Execute(string groupName, Screen screen = null);
+        bool Execute(string groupName, Screen screen = null, Playnite.SDK.Events.OnGameStartingEventArgs args = null);
         void AutoClose(string groupName);
 
     }

--- a/Models/Actions/ScriptAction.cs
+++ b/Models/Actions/ScriptAction.cs
@@ -11,7 +11,7 @@ namespace LaunchMate.Models
 {
     public class ScriptAction : ActionBase
     {
-        public override bool Execute(string groupName, Screen screen = null)
+        public override bool Execute(string groupName, Screen screen = null, Playnite.SDK.Events.OnGameStartingEventArgs args = null)
         {
             ILogger logger = LogManager.GetLogger();
             if ((Target ?? "") == string.Empty)

--- a/Models/Actions/StartServiceAction.cs
+++ b/Models/Actions/StartServiceAction.cs
@@ -11,7 +11,7 @@ namespace LaunchMate.Models
 {
     public class StartServiceAction : ActionBase
     {
-        public override bool Execute(string groupName, Screen screen = null)
+        public override bool Execute(string groupName, Screen screen = null, Playnite.SDK.Events.OnGameStartingEventArgs args = null)
         {
             ILogger logger = LogManager.GetLogger();
             using(var sc = new ServiceController(Target))

--- a/Models/Actions/StopServiceAction.cs
+++ b/Models/Actions/StopServiceAction.cs
@@ -11,7 +11,7 @@ namespace LaunchMate.Models
 {
     public class StopServiceAction : ActionBase
     {
-        public override bool Execute(string groupName, Screen screen = null)
+        public override bool Execute(string groupName, Screen screen = null, Playnite.SDK.Events.OnGameStartingEventArgs args = null)
         {
             ILogger logger = LogManager.GetLogger();
             using (var sc = new ServiceController(Target))

--- a/Models/Actions/WebAction.cs
+++ b/Models/Actions/WebAction.cs
@@ -18,7 +18,7 @@ namespace LaunchMate.Models
         [DontSerialize]
         public IWebView WebView { get; set; } = null;
 
-        public override bool Execute(string groupName, Screen screen = null)
+        public override bool Execute(string groupName, Screen screen = null, Playnite.SDK.Events.OnGameStartingEventArgs args = null)
         {
             ILogger logger = LogManager.GetLogger();
             if (screen == null)

--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -110,9 +110,11 @@
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
                                     <RowDefinition/>
+                                    <RowDefinition/>
                                 </Grid.RowDefinitions>
                                 <TextBlock Name="ArgsText" Grid.Column="0" Text="{DynamicResource LOCLaunchMateExeArgs}" VerticalAlignment="Center"/>
                                 <TextBox Name="ArgsBox" Grid.Column="1" Text="{Binding Action.TargetArgs, UpdateSourceTrigger=PropertyChanged}"/>
+                                <TextBlock Grid.Row="1" Grid.Column="1" Text="Available variables: %GameDir%, %GameExe%" Foreground="Gray" FontStyle="Italic"/>
                             </Grid>
                             <Grid x:Name="r0c1Web" Grid.Row="2" Grid.Column="0" Margin="0,10,0,10" Visibility="Hidden">
                                 <Grid.ColumnDefinitions>


### PR DESCRIPTION
This commit introduces the ability to use game-specific variables in the application launch parameters. The following variables are now available:

- `%GameDir%`: The installation directory of the game.
- `%GameExe%`: The path to the game's executable.

A help text has been added to the settings UI to inform you about these new variables.